### PR TITLE
Detect microcode as Assembly

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.uc	linguist-language=Assembly
+*.h	linguist-language=C


### PR DESCRIPTION
MicroC files are currently detected and highlighted as UnrealScript. This pull request overrides the detected language to C. As a result of this change, the language statistics will also be updated to:

    99.14%  C
    0.38%   Python
    0.22%   Makefile
    0.19%   Shell
    0.04%   Awk
    0.01%   C++

You can get [a preview of syntax highlighting using Lightshow](https://github-lightshow.herokuapp.com/?utf8=%E2%9C%93&scope=source.c&grammar_format=auto&grammar_url=&grammar_text=&code_source=from-url&code_url=https%3A%2F%2Fgithub.com%2FNetronome%2Fnic-firmware%2Fblob%2F092d992f10fc8b4447baf352812f733de516b8b9%2Ffirmware%2Fapps%2Fnic%2Factions.uc&code=).

It's also possible to hide the MicroC files from language statistics without loosing syntax highlighting, by marking them (linguist-)vendored (see [documentation for Linguist overrides](https://github.com/github/linguist/#overrides)).