### PR TITLE
process_%s_reconfig tests

### DIFF
--- a/test/lib/map_cmsg_rx.c
+++ b/test/lib/map_cmsg_rx.c
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2019 Netronome Systems, Inc. All rights reserved.
+ *
+ * @file  map_cmsg_rx.c
+ * @brief This file receives MAP cmsgs and free's the buffers 
+ *
+ */
+
+#include <assert.h>
+#include <nfp.h>
+#include <nfp_chipres.h>
+
+#include <stdint.h>
+
+#include <platform.h>
+#include <nfp/me.h>
+#include <nfp/mem_bulk.h>
+#include <nfp/cls.h>
+#include <nfp6000/nfp_me.h>
+
+#include <std/reg_utils.h>
+#include "app_mac_vlan_config_cmsg.c"
+
+__asm .init _pkt_buf_ctm_credits 48 32
+
+void map_cmsg_rx(void)
+{
+    uint32_t q_idx;
+    uint32_t isl, pnum;
+    uint32_t bls;
+    blm_buf_handle_t buf;
+    mem_ring_addr_t q_base;
+    __xread uint32_t workq_data[CMSG_DESC_LW];
+
+    q_idx = _link_sym(MAP_CMSG_Q_IDX);
+    q_base = (_link_sym(MAP_CMSG_Q_BASE) >> 8) & 0xff000000;
+
+    for (;;) {
+        mem_workq_add_thread(q_idx, q_base, &workq_data, sizeof(workq_data));
+
+        isl = workq_data[0] >> 26 & 0x3f;
+        pnum = workq_data[0] >> 16 & 0x1ff;
+        pkt_ctm_free(isl, pnum);
+
+        bls = workq_data[1] >> 29 & 3;
+        buf = workq_data[1] & 0x1fffffff;
+        blm_buf_free(buf, bls);
+
+        __asm ctx_arb[voluntary]
+        pkt_ctm_poll_pe_credit(PKT_BUF_CTM_CREDITS_LINK);
+    }
+}

--- a/test/nfd_app_master/app_master_process_pf_reconfig_dis_vf_dis_tables_test.c
+++ b/test/nfd_app_master/app_master_process_pf_reconfig_dis_vf_dis_tables_test.c
@@ -1,0 +1,71 @@
+//TEST_REQ_BLM
+//TEST_REQ_RESET
+/*
+    Tests the process_pf_reconfig funtion in app_master
+*/
+
+#include "defines.h"
+#include "test.c"
+#include "app_master_test.h"
+#include "vnic_setup.c"
+#include "app_private.c"
+#include "app_config_tables.c"
+#include "nic_tables.c"
+#include "map_cmsg_rx.c"
+#include "app_control_lib.c"
+#include "action_parse.c"
+#include "nfd_cfg_base_decl.c"
+
+void test(uint32_t pcie) {
+    uint32_t type, vnic, vid, control, update, i, pf;
+    int vf;
+    struct nfd_cfg_msg cfg_msg;
+
+    //First indicate VF's are enabled
+    for (vf = 0; vf < NFD_MAX_VFS; vf++) {
+
+        vid = NFD_VF2VID(vf);
+        NFD_VID2VNIC(type, vnic, vid);
+        set_nic_control_word(NIC_PCI, vid, get_nic_control_word(NIC_PCI, vid) | NFP_NET_CFG_CTRL_ENABLE);
+        setup_sriov_cfg_data(NIC_PCI, vf, TEST_MAC, 0, NFD_VF_CFG_CTRL_LINK_STATE_ENABLE);
+
+    }
+
+    for (pf = 0; pf < NFD_MAX_PFS; pf++) {
+
+        vid = NFD_PF2VID(pf);
+        NFD_VID2VNIC(type, vnic, vid);
+
+        reset_cfg_msg(&cfg_msg, vid, 0);
+
+        setup_pf_mac(NIC_PCI, vid, TEST_MAC);
+
+        set_nic_control_word(NIC_PCI, vid, get_nic_control_word(NIC_PCI, vid) | NFP_NET_CFG_CTRL_ENABLE);
+
+        control = NFD_CFG_PF_CAP & ~NFP_NET_CFG_CTRL_ENABLE;
+        update = NFD_CFG_PF_LEGAL_UPD & ~NFP_NET_CFG_UPDATE_BPF; //BPF updates tested separately
+
+        if (process_pf_reconfig(control, update, vid, vnic, &cfg_msg)) {
+            test_fail();
+        }
+
+        for (vf = 0; vf < NFD_MAX_VFS; vf++) {
+            ctassert(NFD_MAX_VF_QUEUES == 1);
+            verify_host_action_list(NIC_PCI, NFD_VID2QID(NFD_VF2VID(vf), 0));
+        }
+
+    }
+    test_pass();
+}
+
+void main(void)
+{
+    switch (ctx()) {
+        case 0:
+            test(0);
+            break;
+        default:
+            map_cmsg_rx();
+            break;
+    }
+}

--- a/test/nfd_app_master/app_master_process_pf_reconfig_disable_tables_test.c
+++ b/test/nfd_app_master/app_master_process_pf_reconfig_disable_tables_test.c
@@ -1,0 +1,61 @@
+//TEST_REQ_BLM
+//TEST_REQ_RESET
+/*
+    Tests the process_pf_reconfig funtion in app_master
+*/
+
+#include "defines.h"
+#include "test.c"
+#include "app_master_test.h"
+#include "vnic_setup.c"
+#include "app_private.c"
+#include "app_config_tables.c"
+#include "nic_tables.c"
+#include "map_cmsg_rx.c"
+#include "app_control_lib.c"
+#include "action_parse.c"
+#include "nfd_cfg_base_decl.c"
+
+void test(uint32_t pcie) {
+    uint32_t type, vnic, vid, pf, control, update, i;
+    struct nfd_cfg_msg cfg_msg;
+
+    for (pf = 0; pf < NFD_MAX_PFS; pf++) {
+
+        vid = NFD_PF2VID(pf);
+        NFD_VID2VNIC(type, vnic, vid);
+
+        reset_cfg_msg(&cfg_msg, vid, 0);
+
+
+        set_nic_control_word(NIC_PCI, vid,
+            get_nic_control_word(NIC_PCI, vid) | NFP_NET_CFG_CTRL_ENABLE);
+
+        setup_pf_mac(NIC_PCI, vid, TEST_MAC);
+
+        control = NFD_CFG_PF_CAP & ~NFP_NET_CFG_CTRL_ENABLE;
+        update = NFD_CFG_PF_LEGAL_UPD & ~NFP_NET_CFG_UPDATE_BPF; //BPF updates tested separately
+
+        if (process_pf_reconfig(control, update, vid, vnic, &cfg_msg)) {
+            test_fail();
+        }
+
+        verify_wire_action_list(NIC_PCI, vnic);
+
+        for (i = 0; i < NFD_VID_MAXQS(vid); ++i)
+            verify_host_action_list(NIC_PCI, NFD_VID2QID(vid, i));
+    }
+    test_pass();
+}
+
+void main(void)
+{
+    switch (ctx()) {
+        case 0:
+            test(0);
+            break;
+        default:
+            map_cmsg_rx();
+            break;
+    }
+}

--- a/test/nfd_app_master/app_master_process_pf_reconfig_en_vf_en_tables_test.c
+++ b/test/nfd_app_master/app_master_process_pf_reconfig_en_vf_en_tables_test.c
@@ -1,0 +1,71 @@
+//TEST_REQ_BLM
+//TEST_REQ_RESET
+
+/*
+    Tests the process_pf_reconfig funtion in app_master
+*/
+
+#include "defines.h"
+#include "test.c"
+#include "app_master_test.h"
+#include "vnic_setup.c"
+#include "action_parse.c"
+#include "app_private.c"
+#include "app_config_tables.c"
+#include "nic_tables.c"
+#include "map_cmsg_rx.c"
+#include "app_control_lib.c"
+#include "nfd_cfg_base_decl.c"
+
+void test(uint32_t pcie) {
+    uint32_t type, vnic, vid, control, update, i, pf;
+    int vf;
+    struct nfd_cfg_msg cfg_msg;
+
+    //First indicate VF's are enabled
+    for (vf = 0; vf < NFD_MAX_VFS; vf++) {
+
+        vid = NFD_VF2VID(vf);
+        NFD_VID2VNIC(type, vnic, vid);
+
+        set_nic_control_word(NIC_PCI, vid, get_nic_control_word(NIC_PCI, vid) | NFP_NET_CFG_CTRL_ENABLE);
+        setup_sriov_cfg_data(NIC_PCI, vf, TEST_MAC, 0, NFD_VF_CFG_CTRL_LINK_STATE_ENABLE);
+
+    }
+
+    for (pf = 0; pf < NFD_MAX_PFS; pf++) {
+
+        vid = NFD_PF2VID(pf);
+        NFD_VID2VNIC(type, vnic, vid);
+
+        reset_cfg_msg(&cfg_msg, vid, 0);
+
+        setup_pf_mac(NIC_PCI, vid, TEST_MAC);
+
+        control = NFD_CFG_PF_CAP & ~NFP_NET_CFG_CTRL_PROMISC;
+        update = NFD_CFG_PF_LEGAL_UPD & ~NFP_NET_CFG_UPDATE_BPF; //BPF updates tested separately
+
+        if (process_pf_reconfig(control, update, vid, vnic, &cfg_msg)) {
+            test_fail();
+        }
+
+        for (vf = 0; vf < NFD_MAX_VFS; vf++) {
+            ctassert(NFD_MAX_VF_QUEUES == 1);
+            verify_host_action_list(NIC_PCI, NFD_VID2QID(NFD_VF2VID(vf), 0));
+        }
+
+    }
+    test_pass();
+}
+
+void main(void)
+{
+    switch (ctx()) {
+        case 0:
+            test(0);
+            break;
+        default:
+            map_cmsg_rx();
+            break;
+    }
+}

--- a/test/nfd_app_master/app_master_process_pf_reconfig_enable_tables_test.c
+++ b/test/nfd_app_master/app_master_process_pf_reconfig_enable_tables_test.c
@@ -1,0 +1,58 @@
+//TEST_REQ_BLM
+//TEST_REQ_RESET
+
+/*
+    Tests the process_pf_reconfig funtion in app_master
+*/
+
+#include "defines.h"
+#include "test.c"
+#include "app_master_test.h"
+#include "vnic_setup.c"
+#include "action_parse.c"
+#include "app_private.c"
+#include "app_config_tables.c"
+#include "nic_tables.c"
+#include "map_cmsg_rx.c"
+#include "app_control_lib.c"
+#include "nfd_cfg_base_decl.c"
+
+void test(uint32_t pcie) {
+    uint32_t type, vnic, vid, pf, control, update, i;
+    struct nfd_cfg_msg cfg_msg;
+
+    for (pf = 0; pf < NFD_MAX_PFS; pf++) {
+
+        vid = NFD_PF2VID(pf);
+        NFD_VID2VNIC(type, vnic, vid);
+
+        reset_cfg_msg(&cfg_msg, vid, 0);
+
+        setup_pf_mac(NIC_PCI, vid, TEST_MAC);
+
+        control = NFD_CFG_PF_CAP & ~NFP_NET_CFG_CTRL_PROMISC;
+        update = NFD_CFG_PF_LEGAL_UPD & ~NFP_NET_CFG_UPDATE_BPF; //BPF updates tested separately
+
+        if (process_pf_reconfig(control, update, vid, vnic, &cfg_msg)) {
+            test_fail();
+        }
+
+        verify_wire_action_list(NIC_PCI, vnic);
+
+        for (i = 0; i < NFD_VID_MAXQS(vid); ++i)
+            verify_host_action_list(NIC_PCI, NFD_VID2QID(vid, i));
+    }
+    test_pass();
+}
+
+void main(void)
+{
+    switch (ctx()) {
+        case 0:
+            test(0);
+            break;
+        default:
+            map_cmsg_rx();
+            break;
+    }
+}

--- a/test/nfd_app_master/app_master_process_pf_reconfig_invalid_test.c
+++ b/test/nfd_app_master/app_master_process_pf_reconfig_invalid_test.c
@@ -1,0 +1,65 @@
+/*
+    Tests the process_pf_reconfig funtion in app_master
+*/
+
+#include "defines.h"
+#include "test.c"
+#include "app_master_test.h"
+#include "vnic_setup.c"
+#include "app_private.c"
+#include "app_config_tables.c"
+#include "nic_tables.c"
+#include "app_mac_vlan_config_cmsg.c"
+#include "app_control_lib.c"
+#include "nfd_cfg_base_decl.c"
+
+void test(uint32_t pcie) {
+    uint32_t type, vnic, vid, pf, control, update;
+    struct nfd_cfg_msg cfg_msg;
+
+    for (pf = 0; pf < NFD_MAX_PFS; pf++) {
+
+        vid = NFD_PF2VID(pf);
+        NFD_VID2VNIC(type, vnic, vid);
+
+        reset_cfg_msg(&cfg_msg, vid, 0);
+
+        //Invalid control, valid update
+        control = ~NFD_CFG_PF_CAP;
+        update = NFD_CFG_PF_LEGAL_UPD & ~NFP_NET_CFG_UPDATE_BPF; //BPF updates tested separately
+        if (process_pf_reconfig(control, update, vid, vnic, &cfg_msg)) {
+             if(cfg_msg.error == 0)
+                 test_fail();
+        } else {
+            test_fail();
+        }
+
+        //Valid control, invalid update
+        control = NFD_CFG_PF_CAP;
+        update = ~NFD_CFG_PF_LEGAL_UPD;
+        if (process_pf_reconfig(control, update, vid, vnic, &cfg_msg)) {
+             if(cfg_msg.error == 0)
+                 test_fail();
+        } else {
+            test_fail();
+        }
+
+        //invalid control, invalid update
+        control = ~NFD_CFG_PF_CAP;
+        update = ~NFD_CFG_PF_LEGAL_UPD;
+        if (process_pf_reconfig(control, update, vid, vnic, &cfg_msg)) {
+             if(cfg_msg.error == 0)
+                 test_fail();
+        } else {
+            test_fail();
+        }
+    }
+
+    test_pass();
+}
+
+void main(void)
+{
+    single_ctx_test();
+    test(0);
+}

--- a/test/nfd_app_master/app_master_process_pf_reconfig_nic_control_word_disable_test.c
+++ b/test/nfd_app_master/app_master_process_pf_reconfig_nic_control_word_disable_test.c
@@ -1,0 +1,60 @@
+//TEST_REQ_BLM
+//TEST_REQ_RESET
+
+/*
+    Tests the process_pf_reconfig funtion in app_master
+*/
+
+#include "defines.h"
+#include "test.c"
+#include "app_master_test.h"
+#include "vnic_setup.c"
+#include "app_private.c"
+#include "app_config_tables.c"
+#include "nic_tables.c"
+#include "map_cmsg_rx.c"
+#include "app_control_lib.c"
+#include "nfd_cfg_base_decl.c"
+
+void test(uint32_t pcie) {
+    uint32_t type, vnic, vid, pf, control, update;
+    uint32_t test_control;
+    struct nfd_cfg_msg cfg_msg;
+
+    for (pf = 0; pf < NFD_MAX_PFS; pf++) {
+
+        vid = NFD_PF2VID(pf);
+        NFD_VID2VNIC(type, vnic, vid);
+
+        reset_cfg_msg(&cfg_msg, vid, 0);
+
+        set_nic_control_word(NIC_PCI, vid, NFP_NET_CFG_CTRL_ENABLE);
+
+        /*If nic_control_word[vid] has NFP_NET_CFG_CTRL_ENABLE set and
+         * ~NFP_NET_CFG_CTRL_ENABLE is passed to the function, then it
+         * must be ~NFP_NET_CFG_CTRL_ENABLE*/
+        control = NFD_CFG_PF_CAP & ~NFP_NET_CFG_CTRL_ENABLE;
+        update = NFD_CFG_PF_LEGAL_UPD & ~NFP_NET_CFG_UPDATE_BPF; //BPF updates tested separately
+
+        if (process_pf_reconfig(control, update, vid, vnic, &cfg_msg))
+            test_fail();
+
+        test_control = get_nic_control_word(NIC_PCI, vid);
+        test_assert_equal(test_control & NFP_NET_CFG_CTRL_ENABLE, 0);
+    }
+
+    test_pass();
+}
+
+void main(void)
+{
+    switch (ctx()) {
+        case 0:
+            test(0);
+            break;
+        default:
+            map_cmsg_rx();
+            break;
+    }
+}
+

--- a/test/nfd_app_master/app_master_process_pf_reconfig_nic_control_word_enable_test.c
+++ b/test/nfd_app_master/app_master_process_pf_reconfig_nic_control_word_enable_test.c
@@ -1,0 +1,62 @@
+//TEST_REQ_BLM
+//TEST_REQ_RESET
+
+/*
+    Tests the process_pf_reconfig funtion in app_master
+*/
+
+#include "defines.h"
+#include "test.c"
+#include "app_master_test.h"
+#include "vnic_setup.c"
+#include "app_private.c"
+#include "app_config_tables.c"
+#include "nic_tables.c"
+#include "map_cmsg_rx.c"
+#include "app_control_lib.c"
+#include "nfd_cfg_base_decl.c"
+
+void test(uint32_t pcie) {
+    uint32_t type, vnic, vid, pf, control, update;
+    uint32_t test_control;
+    struct nfd_cfg_msg cfg_msg;
+
+    for (pf = 0; pf < NFD_MAX_PFS; pf++) {
+
+        vid = NFD_PF2VID(pf);
+        NFD_VID2VNIC(type, vnic, vid);
+
+        setup_pf_mac(pcie, vid, TEST_MAC);
+        reset_cfg_msg(&cfg_msg, vid, 0);
+
+        set_nic_control_word(NIC_PCI, vid, get_nic_control_word(NIC_PCI, vid) & ~NFP_NET_CFG_CTRL_ENABLE);
+
+        /*If nic_control_word[vid] is not NFP_NET_CFG_CTRL_ENABLE and
+         * NFP_NET_CFG_CTRL_ENABLE is passed to the function, then it
+         * must be NFP_NET_CFG_CTRL_ENABLE*/
+        control = NFP_NET_CFG_CTRL_ENABLE;
+        update = NFD_CFG_PF_LEGAL_UPD & ~NFP_NET_CFG_UPDATE_BPF; //BPF updates tested separately
+
+        if (process_pf_reconfig(control, update, vid, vnic, &cfg_msg)) {
+            test_fail();
+        }
+        
+        test_control = get_nic_control_word(NIC_PCI, vid);
+        test_assert_equal(test_control & NFP_NET_CFG_CTRL_ENABLE, NFP_NET_CFG_CTRL_ENABLE);
+    }
+
+    test_pass();
+}
+
+void main(void)
+{
+    switch (ctx()) {
+        case 0:
+            test(0);
+            break;
+        default:
+            map_cmsg_rx();
+            break;
+    }
+}
+

--- a/test/nfd_app_master/app_master_process_pf_reconfig_valid_test.c
+++ b/test/nfd_app_master/app_master_process_pf_reconfig_valid_test.c
@@ -1,0 +1,52 @@
+//TEST_REQ_BLM
+//TEST_REQ_RESET
+
+/*
+    Tests the process_pf_reconfig funtion in app_master
+*/
+
+#include "defines.h"
+#include "test.c"
+#include "app_master_test.h"
+#include "vnic_setup.c"
+#include "app_private.c"
+#include "app_config_tables.c"
+#include "nic_tables.c"
+#include "map_cmsg_rx.c"
+#include "app_control_lib.c"
+#include "nfd_cfg_base_decl.c"
+
+void test(uint32_t pcie) {
+    uint32_t type, vnic, vid, pf, control, update;
+    struct nfd_cfg_msg cfg_msg;
+
+    for (pf = 0; pf < NFD_MAX_PFS; pf++) {
+
+        vid = NFD_PF2VID(pf);
+        NFD_VID2VNIC(type, vnic, vid);
+
+        reset_cfg_msg(&cfg_msg, vid, 0);
+        setup_pf_mac(pcie, vid, TEST_MAC);
+
+        control = NFD_CFG_PF_CAP;
+        update = NFD_CFG_PF_LEGAL_UPD & ~NFP_NET_CFG_UPDATE_BPF; //BPF updates tested separately
+        if (process_pf_reconfig(control, update, vid, vnic, &cfg_msg)) {
+            test_fail();
+        }
+    }
+
+    test_pass();
+}
+
+void main(void)
+{
+    switch (ctx()) {
+        case 0:
+            test(0);
+            break;
+        default:
+            map_cmsg_rx();
+            break;
+    }
+}
+

--- a/test/nfd_app_master/app_master_process_pf_reconfig_vf_enable_test.c
+++ b/test/nfd_app_master/app_master_process_pf_reconfig_vf_enable_test.c
@@ -1,0 +1,67 @@
+//TEST_REQ_BLM
+//TEST_REQ_RESET
+
+/*
+    Tests the process_pf_reconfig funtion in app_master
+*/
+
+#include "defines.h"
+#include "test.c"
+#include "app_master_test.h"
+#include "vnic_setup.c"
+#include "app_private.c"
+#include "app_config_tables.c"
+#include "nic_tables.c"
+#include "map_cmsg_rx.c"
+#include "app_control_lib.c"
+#include "nfd_cfg_base_decl.c"
+
+void test(uint32_t pcie) {
+    uint32_t type, vnic, vid, pf, control, update;
+    int vf;
+    uint32_t test_control;
+    struct nfd_cfg_msg cfg_msg;
+
+    //First indicate VF's are enabled
+    for (vf = 0; vf < NFD_MAX_VFS; vf++) {
+
+        vid = NFD_VF2VID(vf);
+        NFD_VID2VNIC(type, vnic, vid);
+
+        set_nic_control_word(NIC_PCI, vid, get_nic_control_word(NIC_PCI, vid) | NFP_NET_CFG_CTRL_ENABLE);
+        setup_sriov_cfg_data(NIC_PCI, vf, TEST_MAC, 0, NFD_VF_CFG_CTRL_LINK_STATE_ENABLE);
+
+    }
+
+    for (pf = 0; pf < NFD_MAX_PFS; pf++) {
+
+        vid = NFD_PF2VID(pf);
+        NFD_VID2VNIC(type, vnic, vid);
+
+        reset_cfg_msg(&cfg_msg, vid, 0);
+
+        setup_pf_mac(NIC_PCI, vid, TEST_MAC);
+
+        control = NFD_CFG_PF_CAP;
+        update = NFD_CFG_PF_LEGAL_UPD & ~NFP_NET_CFG_UPDATE_BPF; //BPF updates tested separately
+
+        if (process_pf_reconfig(control, update, vid, vnic, &cfg_msg)) {
+            test_fail();
+        }
+    }
+
+    test_pass();
+}
+
+void main(void)
+{
+    switch (ctx()) {
+        case 0:
+            test(0);
+            break;
+        default:
+            map_cmsg_rx();
+            break;
+    }
+}
+

--- a/test/nfd_app_master/app_master_process_vf_reconfig_disable_tables_test.c
+++ b/test/nfd_app_master/app_master_process_vf_reconfig_disable_tables_test.c
@@ -1,0 +1,68 @@
+//TEST_REQ_BLM
+//TEST_REQ_RESET
+
+/*
+    Tests the process_pf_reconfig funtion in app_master
+*/
+
+#include "defines.h"
+#include "test.c"
+#include "app_master_test.h"
+#include "vnic_setup.c"
+#include "app_private.c"
+#include "app_config_tables.c"
+#include "nic_tables.c"
+#include "map_cmsg_rx.c"
+#include "app_control_lib.c"
+#include "action_parse.c"
+#include "nfd_cfg_base_decl.c"
+
+void test(uint32_t pcie) {
+    uint32_t type, vnic, vid, pf, control, update;
+    int vf;
+    struct nfd_cfg_msg cfg_msg;
+
+    //First indicate PF's are enabled
+    for (pf = 0; pf < NFD_MAX_PFS; pf++) {
+        set_nic_control_word(NIC_PCI, NFD_PF2VID(pf),
+                get_nic_control_word(NIC_PCI,
+                    NFD_PF2VID(pf)) | NFP_NET_CFG_CTRL_ENABLE);
+        setup_pf_mac(NIC_PCI, NFD_PF2VID(pf), TEST_MAC);
+    }
+
+    for (vf = 0; vf < NFD_MAX_VFS; vf++) {
+
+        vid = NFD_VF2VID(vf);
+        NFD_VID2VNIC(type, vnic, vid);
+
+        reset_cfg_msg(&cfg_msg, vid, 0);
+
+        setup_sriov_cfg_data(NIC_PCI, vf, TEST_MAC, 0, NFD_VF_CFG_CTRL_LINK_STATE_ENABLE);
+
+        control = NFD_CFG_VF_CAP & ~NFP_NET_CFG_CTRL_ENABLE;
+        update = NFD_CFG_VF_LEGAL_UPD;
+        if (process_vf_reconfig(control, update, vid, &cfg_msg)) {
+            test_fail();
+        }
+
+    }
+
+    for (vf = 0; vf < NFD_MAX_VFS; vf++) {
+        ctassert(NFD_MAX_VF_QUEUES == 1);
+        verify_host_action_list(NIC_PCI, NFD_VID2QID(NFD_VF2VID(vf), 0));
+    }
+
+    test_pass();
+}
+
+void main(void)
+{
+    switch (ctx()) {
+        case 0:
+            test(0);
+            break;
+        default:
+            map_cmsg_rx();
+            break;
+    }
+}

--- a/test/nfd_app_master/app_master_process_vf_reconfig_en_ls_cfg_bar_test.c
+++ b/test/nfd_app_master/app_master_process_vf_reconfig_en_ls_cfg_bar_test.c
@@ -1,0 +1,118 @@
+//TEST_REQ_BLM
+//TEST_REQ_RESET
+
+/*
+    Tests the process_vf_reconfig funtion in app_master
+*/
+
+#include "defines.h"
+#include "test.c"
+#include "app_master_test.h"
+#include "vnic_setup.c"
+#include "app_private.c"
+#include "app_config_tables.c"
+#include "nic_tables.c"
+#include "map_cmsg_rx.c"
+#include "app_control_lib.c"
+#include "action_parse.c"
+#include "nfd_cfg_base_decl.c"
+
+#define NFP_NET_CFG_CTRL_DISABLE (~NFP_NET_CFG_CTRL_ENABLE & 1)
+
+void reconfig(uint32_t vf_enable, uint32_t vf_mode, uint32_t pf_link)
+{
+    uint32_t type, vnic, vid, control, update;
+    uint32_t pf = 0;
+    int vf;
+    struct nfd_cfg_msg cfg_msg;
+
+    set_nic_control_word(NIC_PCI, NFD_PF2VID(pf),
+            get_nic_control_word(NIC_PCI,
+                NFD_PF2VID(pf)) | NFP_NET_CFG_CTRL_ENABLE);
+    setup_pf_mac(NIC_PCI, NFD_PF2VID(pf), TEST_MAC);
+    set_ls_current(NIC_PCI, NFD_PF2VID(pf), pf_link & 1);
+
+    for (vf = 0; vf < NFD_MAX_VFS; vf++) {
+
+        vid = NFD_VF2VID(vf);
+        NFD_VID2VNIC(type, vnic, vid);
+
+        reset_cfg_msg(&cfg_msg, vid, 0);
+
+        setup_sriov_cfg_data(NIC_PCI, vf, TEST_MAC, 0, vf_mode & 3);
+
+        control = NFD_CFG_VF_CAP & (~NFP_NET_CFG_CTRL_ENABLE);
+        control |= vf_enable;
+        update = NFD_CFG_VF_LEGAL_UPD;
+        if (process_vf_reconfig(control, update, vid, &cfg_msg)) {
+            test_fail();
+        }
+    }
+}
+
+void verify_ls_cfg_bar(const uint32_t pcie, uint32_t expected_ls)
+{
+    int vf;
+    __xread uint32_t sts;
+
+    for (vf = 0; vf < NFD_MAX_VFS; vf++) {
+        mem_read32(&sts,
+                nfd_cfg_bar_base(pcie, NFD_VF2VID(vf)) + NFP_NET_CFG_STS,
+                sizeof(sts));
+
+        test_assert_equal((sts & 1), expected_ls);
+    }
+}
+
+void test(uint32_t pcie) {
+
+    reconfig(NFP_NET_CFG_CTRL_DISABLE, NFD_VF_CFG_CTRL_LINK_STATE_AUTO, LINK_DOWN);
+    verify_ls_cfg_bar(NIC_PCI, LINK_DOWN);
+
+    reconfig(NFP_NET_CFG_CTRL_DISABLE, NFD_VF_CFG_CTRL_LINK_STATE_AUTO, LINK_UP);
+    verify_ls_cfg_bar(NIC_PCI, LINK_UP);
+
+    reconfig(NFP_NET_CFG_CTRL_DISABLE, NFD_VF_CFG_CTRL_LINK_STATE_ENABLE, LINK_DOWN);
+    verify_ls_cfg_bar(NIC_PCI, LINK_DOWN);
+
+    reconfig(NFP_NET_CFG_CTRL_DISABLE, NFD_VF_CFG_CTRL_LINK_STATE_ENABLE, LINK_UP);
+    verify_ls_cfg_bar(NIC_PCI, LINK_UP);
+
+    reconfig(NFP_NET_CFG_CTRL_DISABLE, NFD_VF_CFG_CTRL_LINK_STATE_DISABLE, LINK_DOWN);
+    verify_ls_cfg_bar(NIC_PCI, LINK_DOWN);
+
+    reconfig(NFP_NET_CFG_CTRL_DISABLE, NFD_VF_CFG_CTRL_LINK_STATE_DISABLE, LINK_UP);
+    verify_ls_cfg_bar(NIC_PCI, LINK_UP);
+
+    reconfig(NFP_NET_CFG_CTRL_ENABLE, NFD_VF_CFG_CTRL_LINK_STATE_AUTO, LINK_DOWN);
+    verify_ls_cfg_bar(NIC_PCI, LINK_DOWN);
+
+    reconfig(NFP_NET_CFG_CTRL_ENABLE, NFD_VF_CFG_CTRL_LINK_STATE_AUTO, LINK_UP);
+    verify_ls_cfg_bar(NIC_PCI, LINK_UP);
+
+    reconfig(NFP_NET_CFG_CTRL_ENABLE, NFD_VF_CFG_CTRL_LINK_STATE_ENABLE, LINK_DOWN);
+    verify_ls_cfg_bar(NIC_PCI, LINK_UP);
+
+    reconfig(NFP_NET_CFG_CTRL_ENABLE, NFD_VF_CFG_CTRL_LINK_STATE_ENABLE, LINK_UP);
+    verify_ls_cfg_bar(NIC_PCI, LINK_UP);
+
+    reconfig(NFP_NET_CFG_CTRL_ENABLE, NFD_VF_CFG_CTRL_LINK_STATE_DISABLE, LINK_DOWN);
+    verify_ls_cfg_bar(NIC_PCI, LINK_DOWN);
+
+    reconfig(NFP_NET_CFG_CTRL_ENABLE, NFD_VF_CFG_CTRL_LINK_STATE_DISABLE, LINK_UP);
+    verify_ls_cfg_bar(NIC_PCI, LINK_UP);
+
+    test_pass();
+}
+
+void main(void)
+{
+    switch (ctx()) {
+        case 0:
+            test(0);
+            break;
+        default:
+            map_cmsg_rx();
+            break;
+    }
+}

--- a/test/nfd_app_master/app_master_process_vf_reconfig_en_ls_test.c
+++ b/test/nfd_app_master/app_master_process_vf_reconfig_en_ls_test.c
@@ -1,0 +1,116 @@
+//TEST_REQ_BLM
+//TEST_REQ_RESET
+
+/*
+    Tests the process_vf_reconfig funtion in app_master
+*/
+
+#include "defines.h"
+#include "test.c"
+#include "app_master_test.h"
+#include "vnic_setup.c"
+#include "app_private.c"
+#include "app_config_tables.c"
+#include "nic_tables.c"
+#include "map_cmsg_rx.c"
+#include "app_control_lib.c"
+#include "action_parse.c"
+#include "nfd_cfg_base_decl.c"
+
+#define NFP_NET_CFG_CTRL_DISABLE (~NFP_NET_CFG_CTRL_ENABLE & 1)
+
+void reconfig(uint32_t vf_enable, uint32_t vf_mode, uint32_t pf_link)
+{
+    uint32_t type, vnic, vid, pf, control, update;
+    int vf;
+    struct nfd_cfg_msg cfg_msg;
+
+    for (pf = 0; pf < NFD_MAX_PFS; pf++) {
+        set_nic_control_word(NIC_PCI, NFD_PF2VID(pf),
+                get_nic_control_word(NIC_PCI,
+                    NFD_PF2VID(pf)) | NFP_NET_CFG_CTRL_ENABLE);
+        setup_pf_mac(NIC_PCI, NFD_PF2VID(pf), TEST_MAC);
+        set_ls_current(NIC_PCI, NFD_PF2VID(pf), pf_link & 1);
+    }
+
+    for (vf = 0; vf < NFD_MAX_VFS; vf++) {
+
+        vid = NFD_VF2VID(vf);
+        NFD_VID2VNIC(type, vnic, vid);
+
+        reset_cfg_msg(&cfg_msg, vid, 0);
+
+        setup_sriov_cfg_data(NIC_PCI, vf, TEST_MAC, 0, vf_mode & 3);
+
+        control = NFD_CFG_VF_CAP & (~NFP_NET_CFG_CTRL_ENABLE);
+        control |= vf_enable;
+        update = NFD_CFG_VF_LEGAL_UPD;
+        if (process_vf_reconfig(control, update, vid, &cfg_msg)) {
+            test_fail();
+        }
+    }
+}
+
+void verify_vs_ls_current(uint32_t expected_vs, uint32_t expected_ls)
+{
+    int vf;
+    for (vf = 0; vf < NFD_MAX_VFS; vf++) {
+        test_assert_equal(get_vs_current(NIC_PCI, NFD_VF2VID(vf)), expected_vs);
+        test_assert_equal(get_ls_current(NIC_PCI, NFD_VF2VID(vf)), expected_ls);
+    }
+}
+
+void test(uint32_t pcie) {
+
+    reconfig(NFP_NET_CFG_CTRL_DISABLE, NFD_VF_CFG_CTRL_LINK_STATE_AUTO, LINK_DOWN);
+    verify_vs_ls_current(LINK_DOWN, LINK_DOWN);
+
+    reconfig(NFP_NET_CFG_CTRL_DISABLE, NFD_VF_CFG_CTRL_LINK_STATE_AUTO, LINK_UP);
+    verify_vs_ls_current(LINK_DOWN, LINK_UP);
+
+    reconfig(NFP_NET_CFG_CTRL_DISABLE, NFD_VF_CFG_CTRL_LINK_STATE_ENABLE, LINK_DOWN);
+    verify_vs_ls_current(LINK_DOWN, LINK_DOWN);
+
+    reconfig(NFP_NET_CFG_CTRL_DISABLE, NFD_VF_CFG_CTRL_LINK_STATE_ENABLE, LINK_UP);
+    verify_vs_ls_current(LINK_DOWN, LINK_UP);
+
+    reconfig(NFP_NET_CFG_CTRL_DISABLE, NFD_VF_CFG_CTRL_LINK_STATE_DISABLE, LINK_DOWN);
+    verify_vs_ls_current(LINK_DOWN, LINK_DOWN);
+
+    /*TODO: The below might be a bug?*/
+    reconfig(NFP_NET_CFG_CTRL_DISABLE, NFD_VF_CFG_CTRL_LINK_STATE_DISABLE, LINK_UP);
+    verify_vs_ls_current(LINK_DOWN, LINK_UP);
+
+    reconfig(NFP_NET_CFG_CTRL_ENABLE, NFD_VF_CFG_CTRL_LINK_STATE_AUTO, LINK_DOWN);
+    verify_vs_ls_current(LINK_UP, LINK_DOWN);
+
+    reconfig(NFP_NET_CFG_CTRL_ENABLE, NFD_VF_CFG_CTRL_LINK_STATE_AUTO, LINK_UP);
+    verify_vs_ls_current(LINK_UP, LINK_UP);
+
+    reconfig(NFP_NET_CFG_CTRL_ENABLE, NFD_VF_CFG_CTRL_LINK_STATE_ENABLE, LINK_DOWN);
+    verify_vs_ls_current(LINK_UP, LINK_UP);
+
+    reconfig(NFP_NET_CFG_CTRL_ENABLE, NFD_VF_CFG_CTRL_LINK_STATE_ENABLE, LINK_UP);
+    verify_vs_ls_current(LINK_UP, LINK_UP);
+
+    reconfig(NFP_NET_CFG_CTRL_ENABLE, NFD_VF_CFG_CTRL_LINK_STATE_DISABLE, LINK_DOWN);
+    verify_vs_ls_current(LINK_UP, LINK_DOWN);
+
+    /*TODO: bug?*/
+    reconfig(NFP_NET_CFG_CTRL_ENABLE, NFD_VF_CFG_CTRL_LINK_STATE_DISABLE, LINK_UP);
+    verify_vs_ls_current(LINK_UP, LINK_UP);
+
+    test_pass();
+}
+
+void main(void)
+{
+    switch (ctx()) {
+        case 0:
+            test(0);
+            break;
+        default:
+            map_cmsg_rx();
+            break;
+    }
+}

--- a/test/nfd_app_master/app_master_process_vf_reconfig_en_lsc_test.c
+++ b/test/nfd_app_master/app_master_process_vf_reconfig_en_lsc_test.c
@@ -1,0 +1,136 @@
+//TEST_REQ_BLM
+//TEST_REQ_RESET
+
+/*
+    Tests the process_vf_reconfig funtion in app_master
+*/
+
+#include "defines.h"
+#include "test.c"
+#include "app_master_test.h"
+#include "vnic_setup.c"
+#include "app_private.c"
+#include "app_config_tables.c"
+#include "nic_tables.c"
+#include "map_cmsg_rx.c"
+#include "app_control_lib.c"
+#include "action_parse.c"
+#include "nfd_cfg_base_decl.c"
+
+#define NFP_NET_CFG_CTRL_DISABLE (~NFP_NET_CFG_CTRL_ENABLE & 1)
+
+void reconfig(uint32_t vf_enable, uint32_t vf_mode, uint32_t pf_link)
+{
+    uint32_t type, vnic, vid, control, update;
+    int vf;
+    struct nfd_cfg_msg cfg_msg;
+
+    set_nic_control_word(NIC_PCI, NFD_PF2VID(0),
+            get_nic_control_word(NIC_PCI,
+                NFD_PF2VID(0)) | NFP_NET_CFG_CTRL_ENABLE);
+    setup_pf_mac(NIC_PCI, NFD_PF2VID(0), TEST_MAC);
+    set_ls_current(NIC_PCI, NFD_PF2VID(0), pf_link & 1);
+
+    for (vf = 0; vf < NFD_MAX_VFS; vf++) {
+
+        vid = NFD_VF2VID(vf);
+        NFD_VID2VNIC(type, vnic, vid);
+
+        reset_cfg_msg(&cfg_msg, vid, 0);
+
+        setup_sriov_cfg_data(NIC_PCI, vf, TEST_MAC, 0, vf_mode & 3);
+
+        control = NFD_CFG_VF_CAP & (~NFP_NET_CFG_CTRL_ENABLE);
+        control |= vf_enable;
+        update = NFD_CFG_VF_LEGAL_UPD;
+        if (process_vf_reconfig(control, update, vid, &cfg_msg)) {
+            test_fail();
+        }
+    }
+}
+
+void verify_vf_lsc(uint32_t port, uint32_t expected)
+{
+    int vf;
+    for (vf = 0; vf < NFD_MAX_VFS; vf++)
+        test_assert_equal(get_vf_lsc(NIC_PCI, port, NFD_VF2VID(vf)), expected);
+
+}
+
+
+void verify_other_vf_lsc(uint32_t port, uint32_t expected)
+{
+    int vf, i;
+    for (vf = 0; vf < NFD_MAX_VFS; vf++) {
+        for (i = 0; i < NS_PLATFORM_NUM_PORTS; i++) {
+            if (i != port) 
+                test_assert_equal(get_vf_lsc(NIC_PCI, i, NFD_VF2VID(vf)), expected);
+        }
+    }
+}
+
+void test(uint32_t pcie) {
+    uint32_t port = 0;
+
+    reconfig(NFP_NET_CFG_CTRL_DISABLE, NFD_VF_CFG_CTRL_LINK_STATE_AUTO, LINK_DOWN);
+    verify_vf_lsc(port, LINK_DOWN);
+    verify_other_vf_lsc(port, LINK_DOWN);
+
+    reconfig(NFP_NET_CFG_CTRL_DISABLE, NFD_VF_CFG_CTRL_LINK_STATE_AUTO, LINK_UP);
+    verify_vf_lsc(port, LINK_DOWN);
+    verify_other_vf_lsc(port, LINK_DOWN);
+
+    reconfig(NFP_NET_CFG_CTRL_DISABLE, NFD_VF_CFG_CTRL_LINK_STATE_ENABLE, LINK_DOWN);
+    verify_vf_lsc(port, LINK_DOWN);
+    verify_other_vf_lsc(port, LINK_DOWN);
+
+    reconfig(NFP_NET_CFG_CTRL_DISABLE, NFD_VF_CFG_CTRL_LINK_STATE_ENABLE, LINK_UP);
+    verify_vf_lsc(port, LINK_DOWN);
+    verify_other_vf_lsc(port, LINK_DOWN);
+
+    reconfig(NFP_NET_CFG_CTRL_DISABLE, NFD_VF_CFG_CTRL_LINK_STATE_DISABLE, LINK_DOWN);
+    verify_vf_lsc(port, LINK_DOWN);
+    verify_other_vf_lsc(port, LINK_DOWN);
+
+    reconfig(NFP_NET_CFG_CTRL_DISABLE, NFD_VF_CFG_CTRL_LINK_STATE_DISABLE, LINK_UP);
+    verify_vf_lsc(port, LINK_DOWN);
+    verify_other_vf_lsc(port, LINK_DOWN);
+
+    reconfig(NFP_NET_CFG_CTRL_ENABLE, NFD_VF_CFG_CTRL_LINK_STATE_AUTO, LINK_DOWN);
+    verify_vf_lsc(port, LINK_UP);
+    verify_other_vf_lsc(port, LINK_DOWN);
+
+    reconfig(NFP_NET_CFG_CTRL_ENABLE, NFD_VF_CFG_CTRL_LINK_STATE_AUTO, LINK_UP);
+    verify_vf_lsc(port, LINK_UP);
+    verify_other_vf_lsc(port, LINK_DOWN);
+
+    reconfig(NFP_NET_CFG_CTRL_ENABLE, NFD_VF_CFG_CTRL_LINK_STATE_ENABLE, LINK_DOWN);
+    verify_vf_lsc(port, LINK_DOWN);
+    verify_other_vf_lsc(port, LINK_DOWN);
+
+    reconfig(NFP_NET_CFG_CTRL_ENABLE, NFD_VF_CFG_CTRL_LINK_STATE_ENABLE, LINK_UP);
+    verify_vf_lsc(port, LINK_DOWN);
+    verify_other_vf_lsc(port, LINK_DOWN);
+
+    reconfig(NFP_NET_CFG_CTRL_ENABLE, NFD_VF_CFG_CTRL_LINK_STATE_DISABLE, LINK_DOWN);
+    verify_vf_lsc(port, LINK_DOWN);
+    verify_other_vf_lsc(port, LINK_DOWN);
+
+    reconfig(NFP_NET_CFG_CTRL_ENABLE, NFD_VF_CFG_CTRL_LINK_STATE_DISABLE, LINK_UP);
+    verify_vf_lsc(port, LINK_DOWN);
+    verify_other_vf_lsc(port, LINK_DOWN);
+
+    test_pass();
+}
+
+void main(void)
+{
+    switch (ctx()) {
+        case 0:
+            test(0);
+            break;
+        default:
+            map_cmsg_rx();
+            break;
+    }
+}

--- a/test/nfd_app_master/app_master_process_vf_reconfig_enable_tables_test.c
+++ b/test/nfd_app_master/app_master_process_vf_reconfig_enable_tables_test.c
@@ -1,0 +1,69 @@
+//TEST_REQ_BLM
+//TEST_REQ_RESET
+
+/*
+    Tests the process_pf_reconfig funtion in app_master
+*/
+
+#include "defines.h"
+#include "test.c"
+#include "app_master_test.h"
+#include "vnic_setup.c"
+#include "action_parse.c"
+#include "app_private.c"
+#include "app_config_tables.c"
+#include "nic_tables.c"
+#include "map_cmsg_rx.c"
+#include "app_control_lib.c"
+#include "nfd_cfg_base_decl.c"
+
+void test(uint32_t pcie) {
+    uint32_t type, vnic, vid, pf, control, update;
+    int vf;
+    struct nfd_cfg_msg cfg_msg;
+
+    //First indicate PF's are enabled
+    for (pf = 0; pf < NFD_MAX_PFS; pf++) {
+        set_nic_control_word(NIC_PCI, NFD_PF2VID(pf),
+                get_nic_control_word(NIC_PCI,
+                    NFD_PF2VID(pf)) | NFP_NET_CFG_CTRL_ENABLE);
+        setup_pf_mac(NIC_PCI, NFD_PF2VID(pf), TEST_MAC);
+    }
+
+    for (vf = 0; vf < NFD_MAX_VFS; vf++) {
+
+        vid = NFD_VF2VID(vf);
+        NFD_VID2VNIC(type, vnic, vid);
+
+        reset_cfg_msg(&cfg_msg, vid, 0);
+
+        setup_sriov_cfg_data(NIC_PCI, vf, TEST_MAC, 0, NFD_VF_CFG_CTRL_LINK_STATE_ENABLE);
+
+        control = NFD_CFG_VF_CAP;
+        update = NFD_CFG_VF_LEGAL_UPD;
+        if (process_vf_reconfig(control, update, vid, &cfg_msg)) {
+            test_fail();
+        }
+
+    }
+
+    for (vf = 0; vf < NFD_MAX_VFS; vf++) {
+        ctassert(NFD_MAX_VF_QUEUES == 1);
+        verify_host_action_list(NIC_PCI, NFD_VID2QID(NFD_VF2VID(vf), 0));
+    }
+
+    test_pass();
+}
+
+void main(void)
+{
+    switch (ctx()) {
+        case 0:
+            test(0);
+            break;
+        default:
+            map_cmsg_rx();
+            break;
+    }
+}
+

--- a/test/nfd_app_master/app_master_process_vf_reconfig_invalid_test.c
+++ b/test/nfd_app_master/app_master_process_vf_reconfig_invalid_test.c
@@ -1,0 +1,90 @@
+/*
+    Tests the process_pf_reconfig funtion in app_master
+*/
+
+#include "defines.h"
+#include "test.c"
+#include "app_master_test.h"
+#include "vnic_setup.c"
+#include "action_parse.c"
+#include "app_private.c"
+#include "app_config_tables.c"
+#include "nic_tables.c"
+#include "app_mac_vlan_config_cmsg.c"
+#include "app_control_lib.c"
+#include "nfd_cfg_base_decl.c"
+
+void test(uint32_t pcie) {
+    uint32_t type, vnic, vid, pf, control, update;
+    int vf;
+    struct nfd_cfg_msg cfg_msg;
+
+    //First indicate PF's are enabled
+    for (pf = 0; pf < NFD_MAX_PFS; pf++) {
+        set_nic_control_word(NIC_PCI, NFD_PF2VID(pf),
+                get_nic_control_word(NIC_PCI,
+                    NFD_PF2VID(pf)) | NFP_NET_CFG_CTRL_ENABLE);
+        setup_pf_mac(NIC_PCI, NFD_PF2VID(pf), TEST_MAC);
+    }
+
+    for (vf = 0; vf < NFD_MAX_VFS; vf++) {
+
+        vid = NFD_VF2VID(vf);
+        NFD_VID2VNIC(type, vnic, vid);
+
+        reset_cfg_msg(&cfg_msg, vid, 0);
+
+        //Invalid control, valid update
+        control = ~NFD_CFG_VF_CAP;
+        update = NFD_CFG_VF_LEGAL_UPD;
+        if (process_vf_reconfig(control, update, vid, &cfg_msg)) {
+            if(cfg_msg.error == 0)
+                 test_fail();
+        } else {
+            test_fail();
+        }
+
+        //valid control, invalid update
+        control = NFD_CFG_VF_CAP;
+        update = ~NFD_CFG_VF_LEGAL_UPD;
+        if (process_vf_reconfig(control, update, vid, &cfg_msg)) {
+            if(cfg_msg.error == 0)
+                 test_fail();
+        } else {
+            test_fail();
+        }
+
+        //Invalid control, invalid update
+        control = ~NFD_CFG_VF_CAP;
+        update = ~NFD_CFG_VF_LEGAL_UPD;
+        if (process_vf_reconfig(control, update, vid, &cfg_msg)) {
+            if(cfg_msg.error == 0)
+                 test_fail();
+        } else {
+            test_fail();
+        }
+
+        ctassert(NFD_MAX_PFS >= 1);
+        //Disable PF 0
+        set_nic_control_word(NIC_PCI, NFD_PF2VID(0),
+            get_nic_control_word(NIC_PCI,
+                NFD_PF2VID(0)) & ~NFP_NET_CFG_CTRL_ENABLE);
+
+        //Valid control, valid update. Must fail b/c PF 0 is disabled
+        control = NFD_CFG_VF_CAP;
+        update = NFD_CFG_VF_LEGAL_UPD;
+        if (process_vf_reconfig(control, update, vid, &cfg_msg)) {
+            if(cfg_msg.error == 0)
+                 test_fail();
+        } else {
+            test_fail();
+        }
+    }
+
+    test_pass();
+}
+void main(void)
+{
+    single_ctx_test();
+    test(0);
+}

--- a/test/nfd_app_master/app_master_process_vf_reconfig_valid_test.c
+++ b/test/nfd_app_master/app_master_process_vf_reconfig_valid_test.c
@@ -1,0 +1,62 @@
+//TEST_REQ_BLM
+//TEST_REQ_RESET
+
+/*
+    Tests the process_vf_reconfig funtion in app_master
+*/
+
+#include "defines.h"
+#include "test.c"
+#include "vnic_setup.c"
+#include "app_master_test.h"
+#include "action_parse.c"
+#include "app_private.c"
+#include "app_config_tables.c"
+#include "nic_tables.c"
+#include "map_cmsg_rx.c"
+#include "app_control_lib.c"
+#include "nfd_cfg_base_decl.c"
+
+void test(uint32_t pcie) {
+    uint32_t type, vnic, vid, pf, control, update;
+    int vf;
+    struct nfd_cfg_msg cfg_msg;
+
+    //First indicate PF's are enabled
+    for (pf = 0; pf < NFD_MAX_PFS; pf++) {
+        set_nic_control_word(NIC_PCI, NFD_PF2VID(pf),
+                get_nic_control_word(NIC_PCI,
+                    NFD_PF2VID(pf)) | NFP_NET_CFG_CTRL_ENABLE);
+        setup_pf_mac(NIC_PCI, NFD_PF2VID(pf), TEST_MAC);
+    }
+
+    for (vf = 0; vf < NFD_MAX_VFS; vf++) {
+
+        vid = NFD_VF2VID(vf);
+        NFD_VID2VNIC(type, vnic, vid);
+
+        reset_cfg_msg(&cfg_msg, vid, 0);
+        setup_sriov_cfg_data(NIC_PCI, vf, TEST_MAC, 0, NFD_VF_CFG_CTRL_LINK_STATE_ENABLE);
+
+        control = NFD_CFG_VF_CAP;
+        update = NFD_CFG_VF_LEGAL_UPD;
+        if (process_vf_reconfig(control, update, vid, &cfg_msg)) {
+            test_fail();
+        }
+    }
+
+    test_pass();
+}
+
+void main(void)
+{
+    switch (ctx()) {
+        case 0:
+            test(0);
+            break;
+        default:
+            map_cmsg_rx();
+            break;
+    }
+}
+

--- a/test/nfd_app_master/app_master_process_vf_reconfig_vf_en_pf_tables_test.c
+++ b/test/nfd_app_master/app_master_process_vf_reconfig_vf_en_pf_tables_test.c
@@ -1,0 +1,70 @@
+//TEST_REQ_BLM
+//TEST_REQ_RESET
+
+/*
+    Tests the process_pf_reconfig funtion in app_master
+*/
+
+#include "defines.h"
+#include "test.c"
+#include "app_master_test.h"
+#include "vnic_setup.c"
+#include "action_parse.c"
+#include "app_private.c"
+#include "app_config_tables.c"
+#include "nic_tables.c"
+#include "map_cmsg_rx.c"
+#include "app_control_lib.c"
+#include "nfd_cfg_base_decl.c"
+
+void test(uint32_t pcie) {
+    uint32_t type, vnic, vid, pf, control, update, i;
+    int vf;
+    struct nfd_cfg_msg cfg_msg;
+
+    //First indicate PF's are enabled
+    for (pf = 0; pf < NFD_MAX_PFS; pf++) {
+        set_nic_control_word(NIC_PCI, NFD_PF2VID(pf),
+                get_nic_control_word(NIC_PCI,
+                    NFD_PF2VID(pf)) | NFP_NET_CFG_CTRL_ENABLE);
+        setup_pf_mac(NIC_PCI, NFD_PF2VID(pf), TEST_MAC);
+    }
+
+    for (vf = 0; vf < NFD_MAX_VFS; vf++) {
+
+        vid = NFD_VF2VID(vf);
+        NFD_VID2VNIC(type, vnic, vid);
+
+        reset_cfg_msg(&cfg_msg, vid, 0);
+
+        setup_sriov_cfg_data(NIC_PCI, vf, TEST_MAC, 0, NFD_VF_CFG_CTRL_LINK_STATE_ENABLE);
+
+        control = NFD_CFG_VF_CAP;
+        update = NFD_CFG_VF_LEGAL_UPD;
+        if (process_vf_reconfig(control, update, vid, &cfg_msg)) {
+            test_fail();
+        }
+
+    }
+
+    vid = NFD_PF2VID(0);
+    NFD_VID2VNIC(type, vnic, vid);
+    verify_wire_action_list(NIC_PCI, vnic);
+
+    for (i = 0; i < NFD_VID_MAXQS(vid); ++i)
+        verify_host_action_list(NIC_PCI, NFD_VID2QID(vid, i));
+
+    test_pass();
+}
+
+void main(void)
+{
+    switch (ctx()) {
+        case 0:
+            test(0);
+            break;
+        default:
+            map_cmsg_rx();
+            break;
+    }
+}

--- a/test/nfd_app_master/defines.h
+++ b/test/nfd_app_master/defines.h
@@ -5,13 +5,19 @@
 #ifndef TEST_DEFINES_H
 #define TEST_DEFINES_H
 
-#define NS_PLATFORM_TYPE    1
+
+#define NS_PLATFORM_TYPE        1
+#define NS_PLATFORM_NUM_PORTS   1
 #define BLM_CUSTOM_CONFIG
-#define GRO_NUM_BLOCKS      1
-#define NFD_MAX_VFS 62
-#define NFD_MAX_PF_QUEUES 2
-#define TEST_MAC 0xAA00CCDDEE00ull
-#define APP_WORKER_ISLAND_LIST 0x204
-#define APP_MES_LIST 0x204
+#define GRO_NUM_BLOCKS          1
+#define NFD_MAX_VFS             62
+#define NFD_MAX_PF_QUEUES       2
+#define NFD_MAX_PFS             NS_PLATFORM_NUM_PORTS
+#define NFD_USE_CTRL
+#include <vnic/shared/nfd_ctrl.h> //required for NFD_MAX_CTRL
+#define TEST_MAC                0xAA00CCDDEE00ull
+#define APP_WORKER_ISLAND_LIST  0x204
+#define APP_MES_LIST            0x204
+#define NVNICS                  (NFD_MAX_PFS + NFD_MAX_VFS + NFD_MAX_CTRL)
 
 #endif


### PR DESCRIPTION
This is the first series of patches that will eventually add multi-host
support to CoreNIC. I kick this effort off by expanding on the unit
tests, especially those in app_master. The multi-host changes have
significant impact on app_master, which is why the test coverage must be
expanded.