### PR TITLE
Sriov trust

### DIFF
--- a/firmware/apps/nic/nfd_user_cfg.h
+++ b/firmware/apps/nic/nfd_user_cfg.h
@@ -167,7 +167,8 @@
 #define NFD_VF_CFG_ABI_VER      2
 #define NFD_VF_CFG_CAP                                       \
     (NFD_VF_CFG_MB_CAP_MAC | NFD_VF_CFG_MB_CAP_VLAN |        \
-     NFD_VF_CFG_MB_CAP_SPOOF | NFD_VF_CFG_MB_CAP_LINK_STATE)
+     NFD_VF_CFG_MB_CAP_SPOOF | NFD_VF_CFG_MB_CAP_LINK_STATE |\
+     NFD_VF_CFG_MB_CAP_TRUST)
 
 #define NFD_RSS_HASH_FUNC NFP_NET_CFG_RSS_CRC32
 


### PR DESCRIPTION
These changes allow trusted VFs to change its MAC address even after being
administratively set by the PF. Additionally it allows the use case of a VF
changing its MAC before it is set by the PF.

These changes try to match what other NICs do, mostly Intel, when it
comes to setting the VF's MAC address, not yet for promisc. It is
explained in docs/notes/sriov-trust.rst
