### PR TITLE
tests: Update the VF reconfig unit tests for trusted VF support

### DIFF
--- a/test/lib/vnic_setup.c
+++ b/test/lib/vnic_setup.c
@@ -47,6 +47,14 @@ void setup_pf_mac(const int pcie, uint32_t vid, uint64_t mac)
                                         NFP_NET_CFG_MACADDR), sizeof(mac_xw));
 }
 
+void setup_vf_mac(const int pcie, uint32_t vid, uint64_t mac)
+{
+    __xwrite uint32_t mac_xw[2];
+    mac_xw[0] = (uint32_t)(mac >> 16);
+    mac_xw[1] = (uint32_t)(mac & 0xffff);
+    mem_write64(&mac_xw[0], (__mem void*) (nfd_cfg_bar_base(pcie, vid) +
+                                        NFP_NET_CFG_MACADDR), sizeof(mac_xw));
+}
 void setup_sriov_mb(const int pcie, uint32_t vf, uint32_t flags)
 {
     __xwrite uint32_t sriov_mb_data[4];
@@ -81,7 +89,7 @@ void setup_sriov_cfg_data(const int pcie, uint32_t vf, uint64_t mac, uint16_t vl
      sriov_cfg_data.__raw[1] = 0;
      sriov_cfg_data.__raw[2] = 0;
      sriov_cfg_data.__raw[3] = 0;
-     
+
      sriov_cfg_data.mac_hi = (uint32_t)((mac >> 16));
      sriov_cfg_data.mac_lo = (uint16_t)((mac & 0xffff));
      sriov_cfg_data.vlan_tag = vlan;

--- a/test/nfd_app_master/app_master_process_vf_reconfig_disable_tables_test.c
+++ b/test/nfd_app_master/app_master_process_vf_reconfig_disable_tables_test.c
@@ -37,7 +37,8 @@ void test(uint32_t pcie) {
 
         reset_cfg_msg(&cfg_msg, vid, 0);
 
-        setup_sriov_cfg_data(NIC_PCI, vf, TEST_MAC, 0, NFD_VF_CFG_CTRL_LINK_STATE_ENABLE);
+        setup_sriov_cfg_data(NIC_PCI, vf, 0, 0,
+                NFD_VF_CFG_CTRL_LINK_STATE_ENABLE | (0 << NFD_VF_CFG_CTRL_TRUSTED_shf));
 
         control = NFD_CFG_VF_CAP & ~NFP_NET_CFG_CTRL_ENABLE;
         update = NFD_CFG_VF_LEGAL_UPD;

--- a/test/nfd_app_master/app_master_process_vf_reconfig_en_ls_cfg_bar_test.c
+++ b/test/nfd_app_master/app_master_process_vf_reconfig_en_ls_cfg_bar_test.c
@@ -39,7 +39,9 @@ void reconfig(uint32_t vf_enable, uint32_t vf_mode, uint32_t pf_link)
 
         reset_cfg_msg(&cfg_msg, vid, 0);
 
-        setup_sriov_cfg_data(NIC_PCI, vf, TEST_MAC, 0, vf_mode & 3);
+        setup_vf_mac(NIC_PCI, vid, TEST_MAC);
+        setup_sriov_cfg_data(NIC_PCI, vf, 0, 0,
+                (vf_mode & 3) | (0 << NFD_VF_CFG_CTRL_TRUSTED_shf));
 
         control = NFD_CFG_VF_CAP & (~NFP_NET_CFG_CTRL_ENABLE);
         control |= vf_enable;

--- a/test/nfd_app_master/app_master_process_vf_reconfig_en_ls_test.c
+++ b/test/nfd_app_master/app_master_process_vf_reconfig_en_ls_test.c
@@ -40,7 +40,9 @@ void reconfig(uint32_t vf_enable, uint32_t vf_mode, uint32_t pf_link)
 
         reset_cfg_msg(&cfg_msg, vid, 0);
 
-        setup_sriov_cfg_data(NIC_PCI, vf, TEST_MAC, 0, vf_mode & 3);
+        setup_vf_mac(NIC_PCI, vid, TEST_MAC);
+        setup_sriov_cfg_data(NIC_PCI, vf, 0, 0,
+                (vf_mode & 3) | (0 << NFD_VF_CFG_CTRL_TRUSTED_shf));
 
         control = NFD_CFG_VF_CAP & (~NFP_NET_CFG_CTRL_ENABLE);
         control |= vf_enable;
@@ -77,7 +79,6 @@ void test(uint32_t pcie) {
     reconfig(NFP_NET_CFG_CTRL_DISABLE, NFD_VF_CFG_CTRL_LINK_STATE_DISABLE, LINK_DOWN);
     verify_vs_ls_current(LINK_DOWN, LINK_DOWN);
 
-    /*TODO: The below might be a bug?*/
     reconfig(NFP_NET_CFG_CTRL_DISABLE, NFD_VF_CFG_CTRL_LINK_STATE_DISABLE, LINK_UP);
     verify_vs_ls_current(LINK_DOWN, LINK_UP);
 
@@ -96,7 +97,6 @@ void test(uint32_t pcie) {
     reconfig(NFP_NET_CFG_CTRL_ENABLE, NFD_VF_CFG_CTRL_LINK_STATE_DISABLE, LINK_DOWN);
     verify_vs_ls_current(LINK_UP, LINK_DOWN);
 
-    /*TODO: bug?*/
     reconfig(NFP_NET_CFG_CTRL_ENABLE, NFD_VF_CFG_CTRL_LINK_STATE_DISABLE, LINK_UP);
     verify_vs_ls_current(LINK_UP, LINK_UP);
 

--- a/test/nfd_app_master/app_master_process_vf_reconfig_en_lsc_test.c
+++ b/test/nfd_app_master/app_master_process_vf_reconfig_en_lsc_test.c
@@ -38,7 +38,9 @@ void reconfig(uint32_t vf_enable, uint32_t vf_mode, uint32_t pf_link)
 
         reset_cfg_msg(&cfg_msg, vid, 0);
 
-        setup_sriov_cfg_data(NIC_PCI, vf, TEST_MAC, 0, vf_mode & 3);
+        setup_vf_mac(NIC_PCI, vid, TEST_MAC);
+        setup_sriov_cfg_data(NIC_PCI, vf, 0, 0,
+                (vf_mode & 3) | ( 0 << NFD_VF_CFG_CTRL_TRUSTED_shf));
 
         control = NFD_CFG_VF_CAP & (~NFP_NET_CFG_CTRL_ENABLE);
         control |= vf_enable;
@@ -63,7 +65,7 @@ void verify_other_vf_lsc(uint32_t port, uint32_t expected)
     int vf, i;
     for (vf = 0; vf < NFD_MAX_VFS; vf++) {
         for (i = 0; i < NS_PLATFORM_NUM_PORTS; i++) {
-            if (i != port) 
+            if (i != port)
                 test_assert_equal(get_vf_lsc(NIC_PCI, i, NFD_VF2VID(vf)), expected);
         }
     }

--- a/test/nfd_app_master/app_master_process_vf_reconfig_enable_tables_test.c
+++ b/test/nfd_app_master/app_master_process_vf_reconfig_enable_tables_test.c
@@ -37,7 +37,9 @@ void test(uint32_t pcie) {
 
         reset_cfg_msg(&cfg_msg, vid, 0);
 
-        setup_sriov_cfg_data(NIC_PCI, vf, TEST_MAC, 0, NFD_VF_CFG_CTRL_LINK_STATE_ENABLE);
+        setup_vf_mac(NIC_PCI, vid, TEST_MAC);
+        setup_sriov_cfg_data(NIC_PCI, vf, 0, 0,
+                NFD_VF_CFG_CTRL_LINK_STATE_ENABLE | (0 << NFD_VF_CFG_CTRL_TRUSTED_shf));
 
         control = NFD_CFG_VF_CAP;
         update = NFD_CFG_VF_LEGAL_UPD;

--- a/test/nfd_app_master/app_master_process_vf_reconfig_valid_test.c
+++ b/test/nfd_app_master/app_master_process_vf_reconfig_valid_test.c
@@ -36,7 +36,9 @@ void test(uint32_t pcie) {
         NFD_VID2VNIC(type, vnic, vid);
 
         reset_cfg_msg(&cfg_msg, vid, 0);
-        setup_sriov_cfg_data(NIC_PCI, vf, TEST_MAC, 0, NFD_VF_CFG_CTRL_LINK_STATE_ENABLE);
+        setup_vf_mac(NIC_PCI, vid, TEST_MAC);
+        setup_sriov_cfg_data(NIC_PCI, vf, 0, 0,
+                NFD_VF_CFG_CTRL_LINK_STATE_ENABLE | (0 << NFD_VF_CFG_CTRL_TRUSTED_shf));
 
         control = NFD_CFG_VF_CAP;
         update = NFD_CFG_VF_LEGAL_UPD;

--- a/test/nfd_app_master/app_master_process_vf_reconfig_vf_en_pf_tables_test.c
+++ b/test/nfd_app_master/app_master_process_vf_reconfig_vf_en_pf_tables_test.c
@@ -37,7 +37,9 @@ void test(uint32_t pcie) {
 
         reset_cfg_msg(&cfg_msg, vid, 0);
 
-        setup_sriov_cfg_data(NIC_PCI, vf, TEST_MAC, 0, NFD_VF_CFG_CTRL_LINK_STATE_ENABLE);
+        setup_vf_mac(NIC_PCI, vid, TEST_MAC);
+        setup_sriov_cfg_data(NIC_PCI, vf, 0, 0,
+                NFD_VF_CFG_CTRL_LINK_STATE_ENABLE | (0 << NFD_VF_CFG_CTRL_TRUSTED_shf));
 
         control = NFD_CFG_VF_CAP;
         update = NFD_CFG_VF_LEGAL_UPD;


### PR DESCRIPTION
Since the trusted VF support, extra setup is needed per VF in order to
run the tests. Notably the VF's MAC must be in the BAR before reconfig
(as it would in the real world, because either the PF set is via
firmware or the VF would set it).

Separate unit tests for the trusted VF feature are planned for the
future.

Some TODO comments and whitespace fixes are included.

Signed-off-by: Johan Moraal <johan.moraal@netronome.com>
Reviewed-by: Ciaran Toal <ciaran.toal@netronome.com>
Reviewed-by: Pablo Cascón <pablo.cascon@netronome.com>