### PR TITLE
bpf: support XDP metadata

### DIFF
--- a/firmware/apps/nic/datapath.uc
+++ b/firmware/apps/nic/datapath.uc
@@ -41,7 +41,7 @@ actions#:
     actions_execute(pkt_vec, egress#)
 
 ebpf_reentry#:
-    ebpf_reentry()
+    ebpf_reentry(pkt_vec)
 
 #pragma warning(disable: 4702)
 fatal_error("MAIN LOOP EXIT")


### PR DESCRIPTION
An XDP program can use the bpf_xdp_adjust_meta() hook to prepend up to 32 bytes
of meta data before the packet.  Support this functionality by copying XDP Meta
to the local memory after a BPF program execution and pushing in back right
before delivering the packet.

Signed-off-by: Anton Protopopov <a.s.protopopov@gmail.com>